### PR TITLE
feat(viz-modal): Added auto-focus on text input for visualization modal

### DIFF
--- a/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
+++ b/superset-frontend/src/explore/components/controls/VizTypeControl/VizTypeGallery.tsx
@@ -42,6 +42,7 @@ import {
 import { AntdCollapse } from 'src/components';
 import { Tooltip } from 'src/components/Tooltip';
 import { Input } from 'src/components/Input';
+import { InputRef } from 'antd-v5';
 import Label from 'src/components/Label';
 import { usePluginContext } from 'src/components/DynamicPlugins';
 import Icons from 'src/components/Icons';
@@ -438,10 +439,21 @@ const doesVizMatchSelector = (viz: ChartMetadata, selector: string) =>
 export default function VizTypeGallery(props: VizTypeGalleryProps) {
   const { selectedViz, onChange, onDoubleClick, className, denyList } = props;
   const { mountedPluginMetadata } = usePluginContext();
-  const searchInputRef = useRef<HTMLInputElement>();
+  const searchInputRef = useRef<InputRef>(null);
   const [searchInputValue, setSearchInputValue] = useState('');
   const [isSearchFocused, setIsSearchFocused] = useState(true);
   const isActivelySearching = isSearchFocused && !!searchInputValue;
+
+  // Auto-focus search input when modal opens
+  useEffect(() => {
+    // Small delay allows modal animation to complete
+    const timer = setTimeout(() => {
+      searchInputRef.current?.focus({ preventScroll: true });
+    }, 100);
+
+    // Cleanup timeout on unmount
+    return () => clearTimeout(timer);
+  }, []); // Empty deps = run once on mount
 
   const selectedVizMetadata: ChartMetadata | null = selectedViz
     ? mountedPluginMetadata[selectedViz]
@@ -729,7 +741,7 @@ export default function VizTypeGallery(props: VizTypeGalleryProps) {
       <SearchWrapper>
         <Input
           type="text"
-          ref={searchInputRef as any /* cast required because emotion */}
+          ref={searchInputRef}
           value={searchInputValue}
           placeholder={t('Search all charts')}
           onChange={changeSearch}


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR aims to improve the user's workflow when attempting to change the visualization type of a chart by allowing the user to immediately query for the chart they desire without requiring them to click on the text input first.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="2642" height="1762" alt="Screenshot 2025-10-30 132334" src="https://github.com/user-attachments/assets/61fb2a09-d934-459e-a9f2-e0ff2d0bd4a9" />
Can't type in text input
<img width="2633" height="1730" alt="Screenshot 2025-10-30 132351" src="https://github.com/user-attachments/assets/967303a3-7f7b-4058-ba77-7011ea076728" />
Can type in text input (indicated by blue highlight around input)

### DEMO
https://drive.google.com/file/d/1oBQBEKtb3F2FvXqv8c6CaEUnTLb3cpVj/view?usp=sharing

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
- Open any chart in Explore view
- Click "Change Visualization Type" button
- Wait for the modal to open
- Attempt to type without clicking or moving the cursor
- Verify that text appears in the text input, and the query is being received

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #1 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
