### PR TITLE
fix(sqllab): Fixed strings with angle brackets not rendering in sql lab

### DIFF
--- a/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
+++ b/superset-frontend/packages/superset-ui-core/src/utils/html.tsx
@@ -18,27 +18,33 @@
  */
 import { FilterXSS, getDefaultWhiteList } from 'xss';
 
+const TAG_NAME_PATTERN = /<\/?([a-zA-Z][a-zA-Z0-9-]*)[^>]*>/g;
+
+const allowedHtmlTags = {
+  ...getDefaultWhiteList(),
+  span: ['style', 'class', 'title'],
+  div: ['style', 'class'],
+  a: ['style', 'class', 'href', 'title', 'target'],
+  img: ['style', 'class', 'src', 'alt', 'title', 'width', 'height'],
+  video: [
+    'autoplay',
+    'controls',
+    'loop',
+    'preload',
+    'src',
+    'height',
+    'width',
+    'muted',
+  ],
+};
+
 const xssFilter = new FilterXSS({
-  whiteList: {
-    ...getDefaultWhiteList(),
-    span: ['style', 'class', 'title'],
-    div: ['style', 'class'],
-    a: ['style', 'class', 'href', 'title', 'target'],
-    img: ['style', 'class', 'src', 'alt', 'title', 'width', 'height'],
-    video: [
-      'autoplay',
-      'controls',
-      'loop',
-      'preload',
-      'src',
-      'height',
-      'width',
-      'muted',
-    ],
-  },
+  whiteList: allowedHtmlTags,
   stripIgnoreTag: true,
   css: false,
 });
+
+const ALLOWED_TAG_NAMES = new Set(Object.keys(allowedHtmlTags));
 
 export function sanitizeHtml(htmlString: string) {
   return xssFilter.process(htmlString);
@@ -51,19 +57,43 @@ export function hasHtmlTagPattern(str: string): boolean {
   return htmlTagPattern.test(str);
 }
 
-export function isProbablyHTML(text: string) {
-  const cleanedStr = text.trim().toLowerCase();
+export function isProbablyHTML(text: string): boolean {
+  if (!text || typeof text !== 'string') {
+    return false;
+  }
 
-  if (
-    cleanedStr.startsWith('<!doctype html>') &&
-    hasHtmlTagPattern(cleanedStr)
-  ) {
+  const trimmed = text.trim();
+
+  if (!trimmed.includes('<') || !trimmed.includes('>')) {
+    return false;
+  }
+
+  const lowerTrimmed = trimmed.toLowerCase();
+  if (lowerTrimmed.startsWith('<!doctype html>')) {
     return true;
   }
 
-  const parser = new DOMParser();
-  const doc = parser.parseFromString(cleanedStr, 'text/html');
-  return Array.from(doc.body.childNodes).some(({ nodeType }) => nodeType === 1);
+  const tagNames = new Set<string>();
+  let match;
+
+  TAG_NAME_PATTERN.lastIndex = 0;
+
+  while ((match = TAG_NAME_PATTERN.exec(trimmed)) !== null) {
+    const tagName = match[1].toLowerCase();
+    tagNames.add(tagName);
+  }
+
+  if (tagNames.size === 0) {
+    return false;
+  }
+
+  for (const tagName of tagNames) {
+    if (ALLOWED_TAG_NAMES.has(tagName)) {
+      return true;
+    }
+  }
+
+  return false;
 }
 
 export function sanitizeHtmlIfNeeded(htmlString: string) {


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
This PR fixes a bug in SQL Lab where strings with angle brackets were not displayed, or incorrectly filtered out, regardless of whether the strings contained valid HTML.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
<img width="833" height="486" alt="image" src="https://github.com/user-attachments/assets/8b981fe8-61c4-4544-b1cd-9ad4e20303e0" />

<img width="821" height="462" alt="image" src="https://github.com/user-attachments/assets/162a845a-8275-4a5f-a358-3cf5d60fde34" />

### DEMO
https://drive.google.com/file/d/1OxZwa64uyzNNFjpfZNzVq1-D2Q9cHKbm/view?usp=sharing


### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Open SQL Lab
2. Execute query returning strings with angle brackets
3. Example: SELECT '<test>' as html_string
4. Check results grid
5. Observe that the string is properly displayed

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: Fixes #5 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
