### PR TITLE
Fix(bigquery): ProjectId missing in generated query

### DIFF
--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1468,11 +1468,19 @@ class SqlaTable(
 
     def get_sqla_table(self) -> TableClause:
         tbl = table(self.table_name)
-        if self.schema:
+        
+        if self.catalog and self.schema:
+            tbl.schema = f"{self.catalog}.{self.schema}"
+        elif self.catalog:
+            tbl.schema = self.catalog
+        elif self.schema:
             tbl.schema = self.schema
-        if self.catalog:
-            tbl.catalog = self.catalog
+
         return tbl
+
+
+
+    
 
     def get_from_clause(
         self,

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1468,7 +1468,7 @@ class SqlaTable(
 
     def get_sqla_table(self) -> TableClause:
         tbl = table(self.table_name)
-        
+
         if self.catalog and self.schema:
             tbl.schema = f"{self.catalog}.{self.schema}"
         elif self.catalog:
@@ -1477,10 +1477,6 @@ class SqlaTable(
             tbl.schema = self.schema
 
         return tbl
-
-
-
-    
 
     def get_from_clause(
         self,

--- a/superset/connectors/sqla/models.py
+++ b/superset/connectors/sqla/models.py
@@ -1470,6 +1470,8 @@ class SqlaTable(
         tbl = table(self.table_name)
         if self.schema:
             tbl.schema = self.schema
+        if self.catalog:
+            tbl.catalog = self.catalog
         return tbl
 
     def get_from_clause(

--- a/tests/unit_tests/connectors/sqla/models_test.py
+++ b/tests/unit_tests/connectors/sqla/models_test.py
@@ -287,3 +287,65 @@ def test_normalize_prequery_result_type_custom_sql() -> None:
         sqla_table._normalize_prequery_result_type(row, dimension, columns_by_name)
         == "Car"
     )
+
+
+def test_get_sqla_table_with_catalog() -> None:
+    """
+    Test that get_sqla_table() includes catalog in the table object.
+    """
+    database = Database(database_name="my_db", sqlalchemy_uri="sqlite://")
+    sqla_table = SqlaTable(
+        table_name="orders",
+        schema="sample_orders",
+        catalog="my-project",
+        columns=[],
+        metrics=[],
+        database=database,
+    )
+
+    tbl = sqla_table.get_sqla_table()
+
+    assert tbl.name == "orders"
+    assert tbl.schema == "sample_orders"
+    assert tbl.catalog == "my-project"
+
+
+def test_get_sqla_table_without_catalog() -> None:
+    """
+    Test that get_sqla_table() works correctly when catalog is None.
+    """
+    database = Database(database_name="my_db", sqlalchemy_uri="sqlite://")
+    sqla_table = SqlaTable(
+        table_name="orders",
+        schema="sample_orders",
+        catalog=None,
+        columns=[],
+        metrics=[],
+        database=database,
+    )
+
+    tbl = sqla_table.get_sqla_table()
+
+    assert tbl.name == "orders"
+    assert tbl.schema == "sample_orders"
+    assert not hasattr(tbl, "catalog") or tbl.catalog is None
+
+
+def test_get_sqla_table_with_schema_no_catalog() -> None:
+    """
+    Test that get_sqla_table() works with schema but no catalog (common case).
+    """
+    database = Database(database_name="my_db", sqlalchemy_uri="sqlite://")
+    sqla_table = SqlaTable(
+        table_name="users",
+        schema="public",
+        columns=[],
+        metrics=[],
+        database=database,
+    )
+
+    tbl = sqla_table.get_sqla_table()
+
+    assert tbl.name == "users"
+    assert tbl.schema == "public"
+    assert not hasattr(tbl, "catalog") or tbl.catalog is None

--- a/tests/unit_tests/connectors/sqla/models_test.py
+++ b/tests/unit_tests/connectors/sqla/models_test.py
@@ -292,6 +292,9 @@ def test_normalize_prequery_result_type_custom_sql() -> None:
 def test_get_sqla_table_with_catalog() -> None:
     """
     Test that get_sqla_table() includes catalog in the table object.
+
+    For SQLAlchemy 1.4 compatibility, catalog and schema are combined
+    into the schema field as "catalog.schema".
     """
     database = Database(database_name="my_db", sqlalchemy_uri="sqlite://")
     sqla_table = SqlaTable(
@@ -306,8 +309,8 @@ def test_get_sqla_table_with_catalog() -> None:
     tbl = sqla_table.get_sqla_table()
 
     assert tbl.name == "orders"
-    assert tbl.schema == "sample_orders"
-    assert tbl.catalog == "my-project"
+    # Catalog and schema are combined as "catalog.schema"
+    assert tbl.schema == "my-project.sample_orders"
 
 
 def test_get_sqla_table_without_catalog() -> None:
@@ -327,8 +330,8 @@ def test_get_sqla_table_without_catalog() -> None:
     tbl = sqla_table.get_sqla_table()
 
     assert tbl.name == "orders"
+    # Without catalog, schema is used directly
     assert tbl.schema == "sample_orders"
-    assert not hasattr(tbl, "catalog") or tbl.catalog is None
 
 
 def test_get_sqla_table_with_schema_no_catalog() -> None:
@@ -348,4 +351,3 @@ def test_get_sqla_table_with_schema_no_catalog() -> None:
 
     assert tbl.name == "users"
     assert tbl.schema == "public"
-    assert not hasattr(tbl, "catalog") or tbl.catalog is None


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
Fixes SQL queries generated in the Explore view for BigQuery datasets that are missing the project ID (catalog).

When creating charts in the Explore view with BigQuery datasets, the generated SQL queries were missing the project ID, resulting in queries like `FROM `dataset`.`table`` instead of `FROM `project`.`dataset`.`table``. This caused query failures because BigQuery requires the full three-part table name.

**Root Cause:**
The `SqlaTable.get_sqla_table()` method was not including the catalog field when building TableClause objects. While the `catalog` field existed in the model and was stored in the database, it was being ignored during SQL generation.

**Solution:**
For SQLAlchemy 1.4 compatibility (which doesn't support catalog attribute in BigQuery dialect compilation), we encode the catalog into the schema field as `"catalog.schema"`. The BigQuery dialect then properly formats this as a three-part identifier: `` `project`.`dataset`.`table` ``.

**Changes:**
- Modified `get_sqla_table()` to combine catalog and schema when both are present
- Added 3 unit tests to verify catalog encoding with different combinations of catalog/schema values
- Maintains backward compatibility for datasets without catalog values

This fix ensures BigQuery queries include the full project.dataset.table path, allowing charts and queries to execute successfully.

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
BEFORE
<img width="3814" height="2022" alt="image" src="https://github.com/user-attachments/assets/62735afe-139a-47bd-b0a2-fc32be0e8ab2" />

AFTER
<img width="3814" height="2022" alt="image" src="https://github.com/user-attachments/assets/1b600c96-399e-4c9b-8d12-e7ce83c0b5b7" />

### DEMO
https://drive.google.com/file/d/1uX8XCxn9aGdtPlfUEF3CZbBx38BzKC2F/view?usp=sharing

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Connect to a BigQuery database
2. Create a dataset with a specific project ID
3. Navigate to Explore view 
4. Create a chart using the BigQuery dataset
5. Click "View Query"
6. Observe the generated SQL query
7. Notice the project ID in table reference

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #3 
- [ ] Required feature flags:
- [ ] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
