### PR TITLE
fix(table-chart): improve sort descending checkbox visibility and positioning

### DIFF
--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -328,6 +328,25 @@ const config: ControlPanelConfig = {
         ],
         [
           {
+            name: 'order_desc',
+            override: {
+              label: t('Sort descending'),
+              default: true,
+              description: t(
+                'If enabled, this control sorts the results/values descending, otherwise it sorts the results ascending.',
+              ),
+              visibility: ({ controls }: ControlPanelsContainerProps) =>
+                isAggMode({ controls }) &&
+                Boolean(
+                  controls?.timeseries_limit_metric?.value &&
+                    !isEmpty(controls?.timeseries_limit_metric?.value),
+                ),
+              resetOnHide: false,
+            },
+          },
+        ],
+        [
+          {
             name: 'server_pagination',
             config: {
               type: 'CheckboxControl',
@@ -359,21 +378,6 @@ const config: ControlPanelConfig = {
               description: t('Rows per page, 0 means no pagination'),
               visibility: ({ controls }: ControlPanelsContainerProps) =>
                 Boolean(controls?.server_pagination?.value),
-            },
-          },
-        ],
-        [
-          {
-            name: 'order_desc',
-            config: {
-              type: 'CheckboxControl',
-              label: t('Sort descending'),
-              default: true,
-              description: t(
-                'If enabled, this control sorts the results/values descending, otherwise it sorts the results ascending.',
-              ),
-              visibility: isAggMode,
-              resetOnHide: false,
             },
           },
         ],

--- a/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
+++ b/superset-frontend/plugins/plugin-chart-table/src/controlPanel.tsx
@@ -331,10 +331,6 @@ const config: ControlPanelConfig = {
             name: 'order_desc',
             override: {
               label: t('Sort descending'),
-              default: true,
-              description: t(
-                'If enabled, this control sorts the results/values descending, otherwise it sorts the results ascending.',
-              ),
               visibility: ({ controls }: ControlPanelsContainerProps) =>
                 isAggMode({ controls }) &&
                 Boolean(


### PR DESCRIPTION
<!---
Please write the PR title following the conventions at https://www.conventionalcommits.org/en/v1.0.0/
Example:
fix(dashboard): load charts correctly
-->

### SUMMARY
<!--- Describe the change below, including rationale and design decisions -->
The "Sort descending" checkbox was always visible in the Table Chart control panel, even when no "Sort query by" metric was selected. This created a confusing UX where users could interact with a non-functional control. Additionally, the checkbox appeared several rows below the "Sort query by" control, making their relationship unclear.

Changes:
- Repositioned "Sort descending" to appear directly after "Sort query by"
- Added conditional visibility: only show checkbox when a sort metric is selected
- Changed from `config` to `override` to leverage shared control definition
- Preserved existing behavior: checkbox only appears in aggregate mode

Technical details:
- Modified controlPanel.tsx to move order_desc control 
- Enhanced visibility logic to check both isAggMode AND timeseries_limit_metric value
- Used `override` instead of `config` to reduce code duplication 

Impact:
- Prevents users from interacting with non-functional controls
- Visual grouping makes control relationships clear
- Checkbox dynamically appears/disappears based on sort metric selection

### BEFORE/AFTER SCREENSHOTS OR ANIMATED GIF
<!--- Skip this if not applicable -->
BEFORE
<img width="3805" height="2042" alt="image" src="https://github.com/user-attachments/assets/9f3210c2-9434-474f-8e69-fa6228dde937" />

AFTER
When a sorting metric is selected, the checkbox should be visible.
<img width="3795" height="2033" alt="image" src="https://github.com/user-attachments/assets/cf5406f7-ab3c-46b9-b3bf-20cde6e4ed34" />

Conversely, when no metric is selected, the checkbox should not be visible.
<img width="3827" height="2049" alt="image" src="https://github.com/user-attachments/assets/48df58ed-e464-4c6a-b4f2-31484a553ba9" />

### VIDEO DEMO
https://drive.google.com/file/d/1IOJm764Z1EHMXamBxmJ1ikQSGgMCU5g7/view?usp=sharing

### TESTING INSTRUCTIONS
<!--- Required! What steps can be taken to manually verify the changes? -->
1. Create or edit a Table Chart in Superset
2. Verify the "Sort Descending" checkbox is hidden when no "Sort Query By" metric is selected
3. Select a metric in the "Sort Query By" control
4. Verify the "Sort Descending" checkbox appears directly below the "Sort Query By" control
5. Toggle the checkbox and run the query to confirm it affects the sort direction
6. Clear the "Sort Query By" metric selection
7. Verify the "Sort Descending" checkbox disappears again
8. Test with server pagination enabled and disabled to ensure the controls are properly positioned in both cases

Expected Results:
- The control panel layout should clearly show the relationship between "Sort Query By" and "Sort Descending"
- Users should not be able to interact with the "Sort Descending" checkbox when it has no effect
- All existing table chart functionality should continue to work as before

### ADDITIONAL INFORMATION
<!--- Check any relevant boxes with "x" -->
<!--- HINT: Include "Fixes #nnn" if you are fixing an existing issue -->
- [x] Has associated issue: #10 
- [ ] Required feature flags:
- [x] Changes UI
- [ ] Includes DB Migration (follow approval process in [SIP-59](https://github.com/apache/superset/issues/13351))
  - [ ] Migration is atomic, supports rollback & is backwards-compatible
  - [ ] Confirm DB migration upgrade and downgrade tested
  - [ ] Runtime estimates and downtime expectations provided
- [ ] Introduces new feature or API
- [ ] Removes existing feature or API
